### PR TITLE
Add initial DVI skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # DVIVAST
+
+Skeleton for a Digital Vehicle Inspection system with a React Native (Expo) frontend and Node.js/Express backend.

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node'
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "dvi-backend",
+  "version": "1.0.0",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "dev": "ts-node-dev src/server.ts",
+    "test": "jest"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "mssql": "^10.0.1"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.17",
+    "@types/jest": "^29.5.2",
+    "@types/node": "^18.15.11",
+    "jest": "^29.5.0",
+    "ts-jest": "^29.0.5",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.2.2",
+    "supertest": "^6.3.3"
+  }
+}

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,0 +1,11 @@
+import express from 'express';
+import workorderRoutes from './routes/workorders';
+import inspectionRoutes from './routes/inspection';
+import { errorHandler } from './middleware/errorHandler';
+
+const app = express();
+app.use(express.json());
+app.use('/api/workorders', workorderRoutes);
+app.use('/api/inspection', inspectionRoutes);
+app.use(errorHandler);
+export default app;

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -1,0 +1,16 @@
+// Database configuration and overridable table names
+export const dbConfig = {
+  user: 'vastoffice',
+  password: 'snowdrift',
+  database: 'VastOffice',
+  server: 'localhost',
+  options: {
+    trustServerCertificate: true
+  }
+};
+
+export const tableNames = {
+  estimateHeader: 'EstmteHdr',
+  lineItem: 'LineItem',
+  mechanic: 'MECHANIC'
+};

--- a/backend/src/controllers/inspectionController.ts
+++ b/backend/src/controllers/inspectionController.ts
@@ -1,0 +1,14 @@
+import { Request, Response, NextFunction } from 'express';
+import { saveInspection, InspectionPayload } from '../services/inspectionService';
+import { log, LogLevel } from '../utils/logger';
+
+export async function postInspection(req: Request, res: Response, next: NextFunction) {
+  try {
+    const payload = req.body as InspectionPayload;
+    await saveInspection(payload);
+    res.status(201).json({ message: 'Inspection saved.' });
+  } catch (err) {
+    log(LogLevel.ERROR, `Failed to save inspection: ${(err as Error).message}`);
+    next(err);
+  }
+}

--- a/backend/src/controllers/workorderController.ts
+++ b/backend/src/controllers/workorderController.ts
@@ -1,0 +1,14 @@
+import { Request, Response, NextFunction } from 'express';
+import { fetchWorkOrders } from '../services/workorderService';
+import { log, LogLevel } from '../utils/logger';
+
+export async function getWorkOrders(req: Request, res: Response, next: NextFunction) {
+  try {
+    const mechanicId = req.query.mechanicId as string;
+    const orders = await fetchWorkOrders(mechanicId);
+    res.json(orders);
+  } catch (err) {
+    log(LogLevel.ERROR, `Failed to get work orders: ${(err as Error).message}`);
+    next(err);
+  }
+}

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -1,0 +1,7 @@
+import { Request, Response, NextFunction } from 'express';
+import { log, LogLevel } from '../utils/logger';
+
+export function errorHandler(err: any, req: Request, res: Response, next: NextFunction) {
+  log(LogLevel.ERROR, `${err.code || 'SERVER_ERROR'} - ${err.message}`);
+  res.status(err.status || 500).json({ error: 'An unexpected error occurred.' });
+}

--- a/backend/src/routes/inspection.ts
+++ b/backend/src/routes/inspection.ts
@@ -1,0 +1,6 @@
+import { Router } from 'express';
+import { postInspection } from '../controllers/inspectionController';
+
+const router = Router();
+router.post('/', postInspection);
+export default router;

--- a/backend/src/routes/workorders.ts
+++ b/backend/src/routes/workorders.ts
@@ -1,0 +1,6 @@
+import { Router } from 'express';
+import { getWorkOrders } from '../controllers/workorderController';
+
+const router = Router();
+router.get('/', getWorkOrders);
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,7 @@
+import app from './app';
+import { log, LogLevel } from './utils/logger';
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  log(LogLevel.INFO, `Server listening on port ${PORT}`);
+});

--- a/backend/src/services/dbService.ts
+++ b/backend/src/services/dbService.ts
@@ -1,0 +1,6 @@
+import mssql from 'mssql';
+import { dbConfig } from '../config/config';
+
+export async function getConnection() {
+  return await mssql.connect(dbConfig);
+}

--- a/backend/src/services/inspectionService.ts
+++ b/backend/src/services/inspectionService.ts
@@ -1,0 +1,37 @@
+import { getConnection } from './dbService';
+import { tableNames } from '../config/config';
+
+export interface PartStatus {
+  part: string;
+  quadrant: string;
+  status: string;
+  note?: string;
+  photoUrl?: string;
+}
+
+export interface InspectionPayload {
+  estimateId: string;
+  mechanicId: string;
+  parts: PartStatus[];
+  timestamp: string;
+}
+
+export async function saveInspection(payload: InspectionPayload) {
+  const db = await getConnection();
+  const table = tableNames.lineItem;
+  for (const part of payload.parts) {
+    const request = db.request();
+    request.input('estimateId', payload.estimateId);
+    request.input('mechanicId', payload.mechanicId);
+    request.input('part', part.part);
+    request.input('quadrant', part.quadrant);
+    request.input('status', part.status);
+    request.input('note', part.note || null);
+    request.input('photoUrl', part.photoUrl || null);
+    request.input('timestamp', payload.timestamp);
+    await request.query(
+      `INSERT INTO ${table} (EstimateId, MechanicId, Part, Quadrant, Status, Note, PhotoUrl, Timestamp)
+       VALUES (@estimateId, @mechanicId, @part, @quadrant, @status, @note, @photoUrl, @timestamp)`
+    );
+  }
+}

--- a/backend/src/services/workorderService.ts
+++ b/backend/src/services/workorderService.ts
@@ -1,0 +1,10 @@
+import { getConnection } from './dbService';
+import { tableNames } from '../config/config';
+
+export async function fetchWorkOrders(mechanicId: string) {
+  const db = await getConnection();
+  const request = db.request();
+  request.input('mechanicId', mechanicId);
+  const result = await request.query(`SELECT * FROM ${tableNames.estimateHeader} WHERE MechanicId = @mechanicId`);
+  return result.recordset;
+}

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -1,0 +1,11 @@
+// Simple logger with timestamp and prefix
+export enum LogLevel {
+  INFO = 'INFO',
+  WARN = 'WARN',
+  ERROR = 'ERROR'
+}
+
+export const log = (level: LogLevel, message: string) => {
+  const timestamp = new Date().toISOString();
+  console.log(`[${timestamp}] [${level}] ${message}`);
+};

--- a/backend/tests/workorders.test.ts
+++ b/backend/tests/workorders.test.ts
@@ -1,0 +1,9 @@
+import request from 'supertest';
+import app from '../src/app';
+
+describe('GET /api/workorders', () => {
+  it('returns 200', async () => {
+    const res = await request(app).get('/api/workorders?mechanicId=test');
+    expect(res.status).toBe(200);
+  });
+});

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "tests"]
+}

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import LoginScreen from './screens/LoginScreen';
+import AssignedWorkOrders from './screens/AssignedWorkOrders';
+import InspectionScreen from './screens/InspectionScreen';
+import { ErrorBoundary } from './components/ErrorBoundary';
+
+export type RootStackParamList = {
+  Login: undefined;
+  Orders: { mechanicId: string };
+  Inspection: { mechanicId: string; estimateId: string };
+};
+
+const Stack = createStackNavigator<RootStackParamList>();
+
+export default function App() {
+  const [mechanicId, setMechanicId] = useState<string | null>(null);
+  return (
+    <ErrorBoundary>
+      <NavigationContainer>
+        <Stack.Navigator>
+          {!mechanicId ? (
+            <Stack.Screen name="Login">
+              {() => <LoginScreen onLogin={setMechanicId} />}
+            </Stack.Screen>
+          ) : (
+            <>
+              <Stack.Screen name="Orders" options={{ title: 'Work Orders' }}>
+                {({ navigation }) => (
+                  <AssignedWorkOrders
+                    mechanicId={mechanicId}
+                    onSelect={estimateId =>
+                      navigation.navigate('Inspection', { mechanicId, estimateId })
+                    }
+                  />
+                )}
+              </Stack.Screen>
+              <Stack.Screen
+                name="Inspection"
+                component={InspectionScreen}
+                initialParams={{ mechanicId, estimateId: '' }}
+              />
+            </>
+          )}
+        </Stack.Navigator>
+      </NavigationContainer>
+    </ErrorBoundary>
+  );
+}

--- a/frontend/api/client.ts
+++ b/frontend/api/client.ts
@@ -1,0 +1,26 @@
+import { log } from '../utils/Logger';
+
+const API_BASE = 'http://localhost:3000/api';
+
+async function request(url: string, options?: RequestInit) {
+  try {
+    const res = await fetch(url, options);
+    if (!res.ok) throw new Error('Network response was not ok');
+    return await res.json();
+  } catch (err) {
+    log('ERROR', (err as Error).message);
+    throw err;
+  }
+}
+
+export function fetchWorkOrders(mechanicId: string) {
+  return request(`${API_BASE}/workorders?mechanicId=${mechanicId}`);
+}
+
+export function submitInspection(payload: any) {
+  return request(`${API_BASE}/inspection`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+}

--- a/frontend/api/client.ts
+++ b/frontend/api/client.ts
@@ -5,7 +5,10 @@ const API_BASE = 'http://localhost:3000/api';
 async function request(url: string, options?: RequestInit) {
   try {
     const res = await fetch(url, options);
-    if (!res.ok) throw new Error('Network response was not ok');
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(text || 'Network error');
+    }
     return await res.json();
   } catch (err) {
     log('ERROR', (err as Error).message);

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -1,0 +1,11 @@
+{
+  "expo": {
+    "name": "DVIVAST",
+    "slug": "dvi",
+    "version": "1.0.0",
+    "sdkVersion": "49.0.0",
+    "platforms": ["ios", "android"],
+    "orientation": "portrait",
+    "jsEngine": "hermes"
+  }
+}

--- a/frontend/components/ErrorBoundary.tsx
+++ b/frontend/components/ErrorBoundary.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { log } from '../utils/Logger';
+
+interface State { hasError: boolean }
+
+export class ErrorBoundary extends React.Component<{}, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error) {
+    log('ERROR', error.message);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <View style={styles.center}>
+          <Text>Something went wrong.</Text>
+        </View>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});

--- a/frontend/components/PartCard.tsx
+++ b/frontend/components/PartCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
-import StatusSelector from './StatusSelector';
+import { StyleSheet } from 'react-native';
+import { Card, TextInput } from 'react-native-paper';
+import StatusSelector, { Status } from './StatusSelector';
 import { InspectionPart } from '../types';
 
 interface Props {
@@ -11,23 +12,27 @@ interface Props {
 
 export default function PartCard({ part, data, onChange }: Props) {
   return (
-    <View style={styles.card}>
-      <Text style={styles.title}>{part}</Text>
-      <StatusSelector status={data.status} onChange={(status) => onChange({ ...data, status })} />
-    </View>
+    <Card style={styles.card}>
+      <Card.Title title={part} titleStyle={styles.title} />
+      <Card.Content>
+        <StatusSelector
+          status={data.status as Status}
+          onChange={status => onChange({ ...data, status })}
+        />
+        <TextInput
+          mode="outlined"
+          placeholder="Add note"
+          value={data.note}
+          onChangeText={note => onChange({ ...data, note })}
+          style={styles.note}
+        />
+      </Card.Content>
+    </Card>
   );
 }
 
 const styles = StyleSheet.create({
-  card: {
-    backgroundColor: '#fff',
-    padding: 16,
-    marginVertical: 8,
-    borderRadius: 8,
-    shadowColor: '#000',
-    shadowOpacity: 0.1,
-    shadowRadius: 4,
-    elevation: 2
-  },
-  title: { fontWeight: 'bold', marginBottom: 8 }
+  card: { marginVertical: 8 },
+  title: { fontWeight: 'bold' },
+  note: { marginTop: 8 }
 });

--- a/frontend/components/PartCard.tsx
+++ b/frontend/components/PartCard.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import StatusSelector from './StatusSelector';
+import { InspectionPart } from '../types';
+
+interface Props {
+  part: string;
+  data: InspectionPart;
+  onChange: (data: InspectionPart) => void;
+}
+
+export default function PartCard({ part, data, onChange }: Props) {
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>{part}</Text>
+      <StatusSelector status={data.status} onChange={(status) => onChange({ ...data, status })} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#fff',
+    padding: 16,
+    marginVertical: 8,
+    borderRadius: 8,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 2
+  },
+  title: { fontWeight: 'bold', marginBottom: 8 }
+});

--- a/frontend/components/StatusSelector.tsx
+++ b/frontend/components/StatusSelector.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { View, TouchableOpacity, Text, StyleSheet } from 'react-native';
+
+interface Props {
+  status: string;
+  onChange: (status: string) => void;
+}
+
+const options = ['GREEN', 'YELLOW', 'RED', 'NA'];
+
+export default function StatusSelector({ status, onChange }: Props) {
+  return (
+    <View style={styles.row}>
+      {options.map(opt => (
+        <TouchableOpacity
+          key={opt}
+          style={[styles.button, status === opt && styles.selected]}
+          onPress={() => onChange(opt)}
+        >
+          <Text>{opt}</Text>
+        </TouchableOpacity>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: { flexDirection: 'row', marginVertical: 8 },
+  button: { flex: 1, padding: 8, alignItems: 'center', borderWidth: 1, borderColor: '#ccc' },
+  selected: { backgroundColor: '#dde' }
+});

--- a/frontend/components/StatusSelector.tsx
+++ b/frontend/components/StatusSelector.tsx
@@ -1,31 +1,38 @@
 import React from 'react';
-import { View, TouchableOpacity, Text, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
+import { IconButton } from 'react-native-paper';
+
+export type Status = 'GREEN' | 'YELLOW' | 'RED' | 'NA';
 
 interface Props {
-  status: string;
-  onChange: (status: string) => void;
+  status: Status;
+  onChange: (status: Status) => void;
 }
 
-const options = ['GREEN', 'YELLOW', 'RED', 'NA'];
+const options: { key: Status; icon: string; color: string }[] = [
+  { key: 'GREEN', icon: 'check-circle-outline', color: '#4caf50' },
+  { key: 'YELLOW', icon: 'alert-circle-outline', color: '#fbc02d' },
+  { key: 'RED', icon: 'close-circle-outline', color: '#f44336' },
+  { key: 'NA', icon: 'minus-circle-outline', color: '#9e9e9e' }
+];
 
 export default function StatusSelector({ status, onChange }: Props) {
   return (
     <View style={styles.row}>
       {options.map(opt => (
-        <TouchableOpacity
-          key={opt}
-          style={[styles.button, status === opt && styles.selected]}
-          onPress={() => onChange(opt)}
-        >
-          <Text>{opt}</Text>
-        </TouchableOpacity>
+        <IconButton
+          key={opt.key}
+          icon={opt.icon}
+          size={28}
+          iconColor={status === opt.key ? '#fff' : opt.color}
+          containerColor={status === opt.key ? opt.color : undefined}
+          onPress={() => onChange(opt.key)}
+        />
       ))}
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  row: { flexDirection: 'row', marginVertical: 8 },
-  button: { flex: 1, padding: 8, alignItems: 'center', borderWidth: 1, borderColor: '#ccc' },
-  selected: { backgroundColor: '#dde' }
+  row: { flexDirection: 'row', justifyContent: 'space-between', marginVertical: 8 }
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "dvi-frontend",
+  "version": "1.0.0",
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "test": "jest"
+  },
+  "dependencies": {
+    "expo": "^49.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.4",
+    "react-native-paper": "^5.10.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.15",
+    "@types/react-native": "^0.72.9",
+    "typescript": "^5.2.2",
+    "jest": "^29.5.0",
+    "@testing-library/react-native": "^12.1.5"
+  }
+}

--- a/frontend/screens/AssignedWorkOrders.tsx
+++ b/frontend/screens/AssignedWorkOrders.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import { FlatList, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { fetchWorkOrders } from '../api/client';
+import { WorkOrder } from '../types';
+
+interface Props { mechanicId: string; onSelect: (id: string) => void }
+
+export default function AssignedWorkOrders({ mechanicId, onSelect }: Props) {
+  const [orders, setOrders] = useState<WorkOrder[]>([]);
+
+  useEffect(() => {
+    fetchWorkOrders(mechanicId).then(setOrders).catch(() => {
+      // error handling
+    });
+  }, [mechanicId]);
+
+  return (
+    <FlatList
+      data={orders}
+      keyExtractor={item => item.EstimateId}
+      renderItem={({ item }) => (
+        <TouchableOpacity style={styles.card} onPress={() => onSelect(item.EstimateId)}>
+          <Text>{item.Vehicle}</Text>
+          <Text>{item.ServiceWriter}</Text>
+        </TouchableOpacity>
+      )}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#fff',
+    padding: 16,
+    marginVertical: 8,
+    marginHorizontal: 16,
+    borderRadius: 8,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 2
+  }
+});

--- a/frontend/screens/AssignedWorkOrders.tsx
+++ b/frontend/screens/AssignedWorkOrders.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { FlatList, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { FlatList, StyleSheet } from 'react-native';
+import { ActivityIndicator, Card, Text, Snackbar } from 'react-native-paper';
 import { fetchWorkOrders } from '../api/client';
 import { WorkOrder } from '../types';
 
@@ -7,37 +8,40 @@ interface Props { mechanicId: string; onSelect: (id: string) => void }
 
 export default function AssignedWorkOrders({ mechanicId, onSelect }: Props) {
   const [orders, setOrders] = useState<WorkOrder[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
 
   useEffect(() => {
-    fetchWorkOrders(mechanicId).then(setOrders).catch(() => {
-      // error handling
-    });
+    setLoading(true);
+    fetchWorkOrders(mechanicId)
+      .then(data => setOrders(data))
+      .catch(() => setError('Failed to load orders'))
+      .finally(() => setLoading(false));
   }, [mechanicId]);
 
+  if (loading) {
+    return <ActivityIndicator style={styles.loader} />;
+  }
+
   return (
-    <FlatList
-      data={orders}
-      keyExtractor={item => item.EstimateId}
-      renderItem={({ item }) => (
-        <TouchableOpacity style={styles.card} onPress={() => onSelect(item.EstimateId)}>
-          <Text>{item.Vehicle}</Text>
-          <Text>{item.ServiceWriter}</Text>
-        </TouchableOpacity>
-      )}
-    />
+    <>
+      <FlatList
+        data={orders}
+        keyExtractor={item => item.EstimateId}
+        contentContainerStyle={styles.list}
+        renderItem={({ item }) => (
+          <Card style={styles.card} onPress={() => onSelect(item.EstimateId)}>
+            <Card.Title title={item.Vehicle} subtitle={item.ServiceWriter} />
+          </Card>
+        )}
+      />
+      <Snackbar visible={!!error} onDismiss={() => setError('')}>{error}</Snackbar>
+    </>
   );
 }
 
 const styles = StyleSheet.create({
-  card: {
-    backgroundColor: '#fff',
-    padding: 16,
-    marginVertical: 8,
-    marginHorizontal: 16,
-    borderRadius: 8,
-    shadowColor: '#000',
-    shadowOpacity: 0.1,
-    shadowRadius: 4,
-    elevation: 2
-  }
+  list: { padding: 16 },
+  card: { marginBottom: 12 },
+  loader: { flex: 1, justifyContent: 'center' }
 });

--- a/frontend/screens/InspectionScreen.tsx
+++ b/frontend/screens/InspectionScreen.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { ScrollView, Button, View } from 'react-native';
+import PartCard from '../components/PartCard';
+import { InspectionPart } from '../types';
+import { submitInspection } from '../api/client';
+
+interface Props { estimateId: string; mechanicId: string }
+
+const parts = ['Brakes', 'Tires', 'Fluids'];
+
+export default function InspectionScreen({ estimateId, mechanicId }: Props) {
+  const [data, setData] = useState<Record<string, InspectionPart>>({});
+
+  const handleSubmit = () => {
+    const payload = {
+      estimateId,
+      mechanicId,
+      parts: Object.entries(data).map(([part, partData]) => ({
+        part,
+        ...partData
+      })),
+      timestamp: new Date().toISOString()
+    };
+    submitInspection(payload).catch(() => {});
+  };
+
+  return (
+    <View style={{ flex: 1 }}>
+      <ScrollView contentContainerStyle={{ padding: 16 }}>
+        {parts.map(part => (
+          <PartCard
+            key={part}
+            part={part}
+            data={data[part] || { quadrant: 'ALL', status: 'NA' }}
+            onChange={newData => setData(prev => ({ ...prev, [part]: newData }))}
+          />
+        ))}
+      </ScrollView>
+      <Button title="Submit" onPress={handleSubmit} />
+    </View>
+  );
+}

--- a/frontend/screens/InspectionScreen.tsx
+++ b/frontend/screens/InspectionScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { ScrollView, Button, View } from 'react-native';
+import { ScrollView, View, StyleSheet } from 'react-native';
+import { Button, Snackbar } from 'react-native-paper';
 import PartCard from '../components/PartCard';
 import { InspectionPart } from '../types';
 import { submitInspection } from '../api/client';
@@ -10,23 +11,26 @@ const parts = ['Brakes', 'Tires', 'Fluids'];
 
 export default function InspectionScreen({ estimateId, mechanicId }: Props) {
   const [data, setData] = useState<Record<string, InspectionPart>>({});
+  const [msg, setMsg] = useState('');
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     const payload = {
       estimateId,
       mechanicId,
-      parts: Object.entries(data).map(([part, partData]) => ({
-        part,
-        ...partData
-      })),
+      parts: Object.entries(data).map(([part, partData]) => ({ part, ...partData })),
       timestamp: new Date().toISOString()
     };
-    submitInspection(payload).catch(() => {});
+    try {
+      await submitInspection(payload);
+      setMsg('Inspection submitted');
+    } catch {
+      setMsg('Failed to submit');
+    }
   };
 
   return (
-    <View style={{ flex: 1 }}>
-      <ScrollView contentContainerStyle={{ padding: 16 }}>
+    <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.scroll}>
         {parts.map(part => (
           <PartCard
             key={part}
@@ -36,7 +40,16 @@ export default function InspectionScreen({ estimateId, mechanicId }: Props) {
           />
         ))}
       </ScrollView>
-      <Button title="Submit" onPress={handleSubmit} />
+      <Button mode="contained" onPress={handleSubmit} style={styles.submit}>
+        Submit Inspection
+      </Button>
+      <Snackbar visible={!!msg} onDismiss={() => setMsg('')}>{msg}</Snackbar>
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  scroll: { padding: 16 },
+  submit: { margin: 16 }
+});

--- a/frontend/screens/LoginScreen.tsx
+++ b/frontend/screens/LoginScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { View, TextInput, Button, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
+import { TextInput, Button, Title } from 'react-native-paper';
 
 interface Props { onLogin: (id: string) => void }
 
@@ -7,18 +8,23 @@ export default function LoginScreen({ onLogin }: Props) {
   const [id, setId] = useState('');
   return (
     <View style={styles.container}>
+      <Title style={styles.title}>Technician Login</Title>
       <TextInput
-        placeholder="Mechanic ID"
-        style={styles.input}
+        mode="outlined"
+        label="Mechanic ID"
         value={id}
         onChangeText={setId}
+        style={styles.input}
       />
-      <Button title="Login" onPress={() => onLogin(id)} />
+      <Button mode="contained" onPress={() => onLogin(id)}>
+        Continue
+      </Button>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: 'center', padding: 16 },
-  input: { borderWidth: 1, borderColor: '#ccc', padding: 8, marginBottom: 16 }
+  container: { flex: 1, justifyContent: 'center', padding: 24 },
+  title: { textAlign: 'center', marginBottom: 24 },
+  input: { marginBottom: 16 }
 });

--- a/frontend/screens/LoginScreen.tsx
+++ b/frontend/screens/LoginScreen.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button, StyleSheet } from 'react-native';
+
+interface Props { onLogin: (id: string) => void }
+
+export default function LoginScreen({ onLogin }: Props) {
+  const [id, setId] = useState('');
+  return (
+    <View style={styles.container}>
+      <TextInput
+        placeholder="Mechanic ID"
+        style={styles.input}
+        value={id}
+        onChangeText={setId}
+      />
+      <Button title="Login" onPress={() => onLogin(id)} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 16 },
+  input: { borderWidth: 1, borderColor: '#ccc', padding: 8, marginBottom: 16 }
+});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "esnext",
+    "jsx": "react",
+    "strict": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -1,0 +1,13 @@
+export interface WorkOrder {
+  EstimateId: string;
+  Vehicle: string;
+  ServiceWriter: string;
+  Date: string;
+}
+
+export interface InspectionPart {
+  quadrant: string;
+  status: 'GREEN' | 'YELLOW' | 'RED' | 'NA';
+  note?: string;
+  photoUrl?: string;
+}

--- a/frontend/utils/Logger.ts
+++ b/frontend/utils/Logger.ts
@@ -1,0 +1,6 @@
+export type LogLevel = 'INFO' | 'WARN' | 'ERROR';
+
+export function log(level: LogLevel, message: string) {
+  const timestamp = new Date().toISOString();
+  console.log(`[${timestamp}] [${level}] ${message}`);
+}


### PR DESCRIPTION
## Summary
- scaffold backend with Express, TypeScript and SQL helpers
- add routes/controllers for work orders and inspections
- implement frontend Expo app with login, work order list and inspection screen
- provide basic logging and error boundary components

## Testing
- `npm test` in `backend` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c15d0d8c832fb225bf6b746d0d5b